### PR TITLE
Estimation module test adjustments

### DIFF
--- a/src/test/kotlin/Data.kt
+++ b/src/test/kotlin/Data.kt
@@ -1,4 +1,9 @@
 object Data {
+    // Default values for KSL RV tests
+    // Must balance between test performance and desired precision, higher sample size = stricter tolerance
+    const val defaultRVSampleSize = 50000
+    const val defaultRVTestTolerance = 0.025
+
     // groundbeef$serving data set from fitdistrplus R library
     // https://cran.r-project.org/web/packages/fitdistrplus/index.html
     val groundBeef = doubleArrayOf(

--- a/src/test/kotlin/Data.kt
+++ b/src/test/kotlin/Data.kt
@@ -1,8 +1,15 @@
+import ksl.utilities.random.rng.RNStreamIfc
+import ksl.utilities.random.rng.RNStreamProvider
+
 object Data {
     // Default values for KSL RV tests
     // Must balance between test performance and desired precision, higher sample size = stricter tolerance
     const val defaultRVSampleSize = 50000
     const val defaultRVTestTolerance = 0.025
+
+    // Use same stream for unit tests so tests are deterministic
+    val rvTestStream: RNStreamIfc
+        get() = RNStreamProvider().defaultRNStream()
 
     // groundbeef$serving data set from fitdistrplus R library
     // https://cran.r-project.org/web/packages/fitdistrplus/index.html

--- a/src/test/kotlin/estimations/ExponentialParametersTest.kt
+++ b/src/test/kotlin/estimations/ExponentialParametersTest.kt
@@ -29,7 +29,7 @@ class ExponentialParametersTest {
         val estimator = ExponentialParameters()
         for (mInt in 1..5) {
             val m = mInt.toDouble()
-            val data = ExponentialRV(m).sample(Data.defaultRVSampleSize)
+            val data = ExponentialRV(m, stream = Data.rvTestStream).sample(Data.defaultRVSampleSize)
             val params = estimator.estimate(data).getOrThrow()
             assert(KSLMath.equal(params[0], m, precision = Data.defaultRVTestTolerance))
                 { "Mean should be $m, was ${params[0]}" }

--- a/src/test/kotlin/estimations/ExponentialParametersTest.kt
+++ b/src/test/kotlin/estimations/ExponentialParametersTest.kt
@@ -30,7 +30,7 @@ class ExponentialParametersTest {
         val estimator = ExponentialParameters()
         for (mInt in 1..5) {
             val m = mInt.toDouble()
-            val data = ExponentialRV(m).sample(10000)
+            val data = ExponentialRV(m).sample(20000)
             val params = estimator.estimate(data).getOrThrow()
             assert(KSLMath.equal(params[0], m, precision = kslPrecision))
                 { "Mean should be $m, was ${params[0]}" }

--- a/src/test/kotlin/estimations/ExponentialParametersTest.kt
+++ b/src/test/kotlin/estimations/ExponentialParametersTest.kt
@@ -1,6 +1,7 @@
 package estimations
 
 import ksl.utilities.math.KSLMath
+import ksl.utilities.random.rvariable.ExponentialRV
 import kotlin.test.Test
 
 class ExponentialParametersTest {
@@ -21,5 +22,18 @@ class ExponentialParametersTest {
     fun estimateToxocara() {
         val params = ExponentialParameters().estimate(Data.toxocara).getOrThrow()
         assert(KSLMath.equal(params[0], toxocaraMean)) { "Mean should be $toxocaraMean, was ${params[0]}" }
+    }
+
+    @Test
+    fun estimateKSL() {
+        val kslPrecision = 0.01
+        val estimator = ExponentialParameters()
+        for (mInt in 1..5) {
+            val m = mInt.toDouble()
+            val data = ExponentialRV(m).sample(10000)
+            val params = estimator.estimate(data).getOrThrow()
+            assert(KSLMath.equal(params[0], m, precision = kslPrecision))
+                { "Mean should be $m, was ${params[0]}" }
+        }
     }
 }

--- a/src/test/kotlin/estimations/ExponentialParametersTest.kt
+++ b/src/test/kotlin/estimations/ExponentialParametersTest.kt
@@ -25,14 +25,13 @@ class ExponentialParametersTest {
     }
 
     @Test
-    fun estimateKSL() {
-        val kslPrecision = 0.01
+    fun estimateRV() {
         val estimator = ExponentialParameters()
         for (mInt in 1..5) {
             val m = mInt.toDouble()
-            val data = ExponentialRV(m).sample(20000)
+            val data = ExponentialRV(m).sample(Data.defaultRVSampleSize)
             val params = estimator.estimate(data).getOrThrow()
-            assert(KSLMath.equal(params[0], m, precision = kslPrecision))
+            assert(KSLMath.equal(params[0], m, precision = Data.defaultRVTestTolerance))
                 { "Mean should be $m, was ${params[0]}" }
         }
     }

--- a/src/test/kotlin/estimations/GammaParametersTest.kt
+++ b/src/test/kotlin/estimations/GammaParametersTest.kt
@@ -2,6 +2,7 @@ package estimations
 
 import Data
 import ksl.utilities.math.KSLMath
+import ksl.utilities.random.rvariable.GammaRV
 import kotlin.test.Test
 
 class GammaParametersTest {
@@ -25,5 +26,23 @@ class GammaParametersTest {
     fun estimateToxocara() {
         val result = GammaParameters().estimate(Data.toxocara)
         assert(result.isFailure) { "Estimation should have failed due to non-positive data, was a success" }
+    }
+
+    @Test
+    fun estimateKSL() {
+        val kslPrecision = 0.04
+        val estimator = GammaParameters()
+        for (shapeInt in 1..5) {
+            for (scaleInt in 1..5) {
+                val shape = shapeInt.toDouble()
+                val scale = scaleInt.toDouble()
+                val data = GammaRV(shape, scale).sample(10000)
+                val params = estimator.estimate(data).getOrThrow()
+                assert(KSLMath.equal(params[0], shape, precision = kslPrecision))
+                    { "Shape should be $shape, was ${params[0]}" }
+                assert(KSLMath.equal(params[1], scale, precision = kslPrecision))
+                    { "Scale should be $scale, was ${params[0]}" }
+            }
+        }
     }
 }

--- a/src/test/kotlin/estimations/GammaParametersTest.kt
+++ b/src/test/kotlin/estimations/GammaParametersTest.kt
@@ -10,11 +10,15 @@ class GammaParametersTest {
     val groundBeefRate = 0.054419110
     val groundBeefScale = 1 / groundBeefRate
 
+    val tolerance = 0.001
+
     @Test
     fun estimateGroundBeef() {
         val params = GammaParameters().estimate(Data.groundBeef).getOrThrow()
-        assert(KSLMath.equal(params[0], groundBeefShape)) { "Shape should be $groundBeefShape, was ${params[0]}" }
-        assert(KSLMath.equal(params[1], groundBeefScale)) { "Scale should be $groundBeefScale, was ${params[1]}" }
+        assert(KSLMath.equal(params[0], groundBeefShape, precision = tolerance))
+            { "Shape should be $groundBeefShape, was ${params[0]}" }
+        assert(KSLMath.equal(params[1], groundBeefScale, precision = tolerance))
+            { "Scale should be $groundBeefScale, was ${params[1]}" }
     }
 
     @Test

--- a/src/test/kotlin/estimations/GammaParametersTest.kt
+++ b/src/test/kotlin/estimations/GammaParametersTest.kt
@@ -29,18 +29,17 @@ class GammaParametersTest {
     }
 
     @Test
-    fun estimateKSL() {
-        val kslPrecision = 0.04
+    fun estimateRV() {
         val estimator = GammaParameters()
         for (shapeInt in 1..5) {
             for (scaleInt in 1..5) {
                 val shape = shapeInt.toDouble()
                 val scale = scaleInt.toDouble()
-                val data = GammaRV(shape, scale).sample(20000)
+                val data = GammaRV(shape, scale).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
-                assert(KSLMath.equal(params[0], shape, precision = kslPrecision))
+                assert(KSLMath.equal(params[0], shape, precision = Data.defaultRVTestTolerance))
                     { "Shape should be $shape, was ${params[0]}" }
-                assert(KSLMath.equal(params[1], scale, precision = kslPrecision))
+                assert(KSLMath.equal(params[1], scale, precision = Data.defaultRVTestTolerance))
                     { "Scale should be $scale, was ${params[1]}" }
             }
         }

--- a/src/test/kotlin/estimations/GammaParametersTest.kt
+++ b/src/test/kotlin/estimations/GammaParametersTest.kt
@@ -35,7 +35,7 @@ class GammaParametersTest {
             for (scaleInt in 1..5) {
                 val shape = shapeInt.toDouble()
                 val scale = scaleInt.toDouble()
-                val data = GammaRV(shape, scale).sample(Data.defaultRVSampleSize)
+                val data = GammaRV(shape, scale, Data.rvTestStream).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
                 assert(KSLMath.equal(params[0], shape, precision = Data.defaultRVTestTolerance))
                     { "Shape should be $shape, was ${params[0]}" }

--- a/src/test/kotlin/estimations/GammaParametersTest.kt
+++ b/src/test/kotlin/estimations/GammaParametersTest.kt
@@ -36,12 +36,12 @@ class GammaParametersTest {
             for (scaleInt in 1..5) {
                 val shape = shapeInt.toDouble()
                 val scale = scaleInt.toDouble()
-                val data = GammaRV(shape, scale).sample(10000)
+                val data = GammaRV(shape, scale).sample(20000)
                 val params = estimator.estimate(data).getOrThrow()
                 assert(KSLMath.equal(params[0], shape, precision = kslPrecision))
                     { "Shape should be $shape, was ${params[0]}" }
                 assert(KSLMath.equal(params[1], scale, precision = kslPrecision))
-                    { "Scale should be $scale, was ${params[0]}" }
+                    { "Scale should be $scale, was ${params[1]}" }
             }
         }
     }

--- a/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
+++ b/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
@@ -1,6 +1,7 @@
 package estimations
 
 import ksl.utilities.math.KSLMath
+import ksl.utilities.random.rvariable.NegativeBinomialRV
 import kotlin.test.Test
 
 class NegativeBinomialParametersTest {
@@ -34,5 +35,23 @@ class NegativeBinomialParametersTest {
             { "Probability should be $toxocaraProb, was $estP"}
         assert(KSLMath.equal(estN, toxocaraSize, precision = tolerance))
             { "Size should be $toxocaraSize, was $estN"}
+    }
+
+    @Test
+    fun estimateKSL() {
+        val kslPrecision = 0.03
+        val estimator = NegativeBinomialParameters()
+        for (pInt in 1..5) {
+            for (nInt in 1..5) {
+                val p = pInt / 10.0
+                val n = nInt.toDouble()
+                val data = NegativeBinomialRV(p, n).sample(50000)
+                val params = estimator.estimate(data).getOrThrow()
+                assert(KSLMath.equal(params[0], p, precision = kslPrecision))
+                    { "ProbSuccess should be $p, was ${params[0]}" }
+                assert(KSLMath.equal(params[1], n, precision = kslPrecision))
+                    { "NumTrials should be $n, was ${params[1]}" }
+            }
+        }
     }
 }

--- a/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
+++ b/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
@@ -10,6 +10,8 @@ class NegativeBinomialParametersTest {
     val toxocaraProb = toxocaraSize / (Data.toxocara.average() + toxocaraSize)
     val toxocaraMu = 8.6802520252
 
+    val tolerance = 0.001
+
     @Test
     fun estimateGroundBeef() {
         val result = NegativeBinomialParameters().estimate(Data.groundBeef)
@@ -21,12 +23,16 @@ class NegativeBinomialParametersTest {
         val estimator = NegativeBinomialParameters()
         val data = Data.toxocara
         val params = estimator.estimate(data).getOrThrow()
-        assert(KSLMath.equal(params[0], toxocaraProb)) { "Probability should be $toxocaraProb, was ${params[0]}" }
-        assert(KSLMath.equal(params[1], toxocaraSize)) { "Size should be $toxocaraSize, was ${params[1]}" }
+        assert(KSLMath.equal(params[0], toxocaraProb, precision = tolerance))
+            { "Probability should be $toxocaraProb, was ${params[0]}" }
+        assert(KSLMath.equal(params[1], toxocaraSize, precision = tolerance))
+            { "Size should be $toxocaraSize, was ${params[1]}" }
 
         val estN = estimator.estimateNumSuccesses(data, params[0]).getOrThrow()
         val estP = estimator.estimateProbSuccess(data, params[1]).getOrThrow()
-        assert(KSLMath.equal(estP, toxocaraProb)) { "Probability should be $toxocaraProb, was $estP"}
-        assert(KSLMath.equal(estN, toxocaraSize)) { "Size should be $toxocaraSize, was $estN"}
+        assert(KSLMath.equal(estP, toxocaraProb, precision = tolerance))
+            { "Probability should be $toxocaraProb, was $estP"}
+        assert(KSLMath.equal(estN, toxocaraSize, precision = tolerance))
+            { "Size should be $toxocaraSize, was $estN"}
     }
 }

--- a/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
+++ b/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
@@ -38,18 +38,17 @@ class NegativeBinomialParametersTest {
     }
 
     @Test
-    fun estimateKSL() {
-        val kslPrecision = 0.03
+    fun estimateRV() {
         val estimator = NegativeBinomialParameters()
         for (pInt in 1..5) {
             for (nInt in 1..5) {
                 val p = pInt / 10.0
                 val n = nInt.toDouble()
-                val data = NegativeBinomialRV(p, n).sample(50000)
+                val data = NegativeBinomialRV(p, n).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
-                assert(KSLMath.equal(params[0], p, precision = kslPrecision))
+                assert(KSLMath.equal(params[0], p, precision = Data.defaultRVTestTolerance))
                     { "ProbSuccess should be $p, was ${params[0]}" }
-                assert(KSLMath.equal(params[1], n, precision = kslPrecision))
+                assert(KSLMath.equal(params[1], n, precision = Data.defaultRVTestTolerance))
                     { "NumTrials should be $n, was ${params[1]}" }
             }
         }

--- a/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
+++ b/src/test/kotlin/estimations/NegativeBinomialParametersTest.kt
@@ -44,7 +44,7 @@ class NegativeBinomialParametersTest {
             for (nInt in 1..5) {
                 val p = pInt / 10.0
                 val n = nInt.toDouble()
-                val data = NegativeBinomialRV(p, n).sample(Data.defaultRVSampleSize)
+                val data = NegativeBinomialRV(p, n, Data.rvTestStream).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
                 assert(KSLMath.equal(params[0], p, precision = Data.defaultRVTestTolerance))
                     { "ProbSuccess should be $p, was ${params[0]}" }

--- a/src/test/kotlin/estimations/NormalParametersTest.kt
+++ b/src/test/kotlin/estimations/NormalParametersTest.kt
@@ -37,7 +37,7 @@ class NormalParametersTest {
             for (vInt in 1..5) {
                 val m = mInt.toDouble()
                 val v = vInt.toDouble()
-                val data = NormalRV(m, v).sample(Data.defaultRVSampleSize)
+                val data = NormalRV(m, v, Data.rvTestStream).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
                 assert(KSLMath.equal(params[0], m, precision = Data.defaultRVTestTolerance))
                     { "Mean should be $m, was ${params[0]}" }

--- a/src/test/kotlin/estimations/NormalParametersTest.kt
+++ b/src/test/kotlin/estimations/NormalParametersTest.kt
@@ -31,18 +31,17 @@ class NormalParametersTest {
     }
 
     @Test
-    fun estimateKSL() {
-        val kslPrecision = 0.03
+    fun estimateRV() {
         val estimator = NormalParameters()
         for (mInt in 1..5) {
             for (vInt in 1..5) {
                 val m = mInt.toDouble()
                 val v = vInt.toDouble()
-                val data = NormalRV(m, v).sample(50000)
+                val data = NormalRV(m, v).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
-                assert(KSLMath.equal(params[0], m, precision = kslPrecision))
+                assert(KSLMath.equal(params[0], m, precision = Data.defaultRVTestTolerance))
                     { "Mean should be $m, was ${params[0]}" }
-                assert(KSLMath.equal(params[1], v, precision = kslPrecision))
+                assert(KSLMath.equal(params[1], v, precision = Data.defaultRVTestTolerance))
                     { "Variance should be $v, was ${params[1]}" }
             }
         }

--- a/src/test/kotlin/estimations/NormalParametersTest.kt
+++ b/src/test/kotlin/estimations/NormalParametersTest.kt
@@ -2,6 +2,7 @@ package estimations
 
 import Data
 import ksl.utilities.math.KSLMath
+import ksl.utilities.random.rvariable.NormalRV
 import kotlin.math.pow
 import kotlin.test.Test
 
@@ -27,5 +28,23 @@ class NormalParametersTest {
         val params = NormalParameters().estimate(Data.toxocara).getOrThrow()
         assert(KSLMath.equal(params[0], toxocaraMean)) { "Mean should be $toxocaraMean, was ${params[0]}" }
         assert(KSLMath.equal(params[1], toxocaraVariance)) { "Variance should be $toxocaraVariance, was ${params[1]}" }
+    }
+
+    @Test
+    fun estimateKSL() {
+        val kslPrecision = 0.03
+        val estimator = NormalParameters()
+        for (mInt in 1..5) {
+            for (vInt in 1..5) {
+                val m = mInt.toDouble()
+                val v = vInt.toDouble()
+                val data = NormalRV(m, v).sample(50000)
+                val params = estimator.estimate(data).getOrThrow()
+                assert(KSLMath.equal(params[0], m, precision = kslPrecision))
+                    { "Mean should be $m, was ${params[0]}" }
+                assert(KSLMath.equal(params[1], v, precision = kslPrecision))
+                    { "Variance should be $v, was ${params[1]}" }
+            }
+        }
     }
 }

--- a/src/test/kotlin/estimations/PoissonParametersTest.kt
+++ b/src/test/kotlin/estimations/PoissonParametersTest.kt
@@ -25,7 +25,7 @@ class PoissonParametersTest {
         val estimator = PoissonParameters()
         for (mInt in 1..5) {
             val m = mInt.toDouble()
-            val data = PoissonRV(m).sample(Data.defaultRVSampleSize)
+            val data = PoissonRV(m, Data.rvTestStream).sample(Data.defaultRVSampleSize)
             val params = estimator.estimate(data).getOrThrow()
             assert(KSLMath.equal(params[0], m, precision = Data.defaultRVTestTolerance))
                 { "Mean should be $m, was ${params[0]}" }

--- a/src/test/kotlin/estimations/PoissonParametersTest.kt
+++ b/src/test/kotlin/estimations/PoissonParametersTest.kt
@@ -21,14 +21,13 @@ class PoissonParametersTest {
     }
 
     @Test
-    fun estimateKSL() {
-        val kslPrecision = 0.01
+    fun estimateRV() {
         val estimator = PoissonParameters()
         for (mInt in 1..5) {
             val m = mInt.toDouble()
-            val data = PoissonRV(m).sample(50000)
+            val data = PoissonRV(m).sample(Data.defaultRVSampleSize)
             val params = estimator.estimate(data).getOrThrow()
-            assert(KSLMath.equal(params[0], m, precision = kslPrecision))
+            assert(KSLMath.equal(params[0], m, precision = Data.defaultRVTestTolerance))
                 { "Mean should be $m, was ${params[0]}" }
         }
     }

--- a/src/test/kotlin/estimations/PoissonParametersTest.kt
+++ b/src/test/kotlin/estimations/PoissonParametersTest.kt
@@ -1,6 +1,7 @@
 package estimations
 
 import ksl.utilities.math.KSLMath
+import ksl.utilities.random.rvariable.PoissonRV
 import kotlin.test.Test
 
 class PoissonParametersTest {
@@ -17,5 +18,18 @@ class PoissonParametersTest {
     fun estimateToxocara() {
         val params = PoissonParameters().estimate(Data.toxocara).getOrThrow()
         assert(KSLMath.equal(params[0], toxocaraLambda)) { "Mean should be $toxocaraLambda, was ${params[0]}" }
+    }
+
+    @Test
+    fun estimateKSL() {
+        val kslPrecision = 0.01
+        val estimator = PoissonParameters()
+        for (mInt in 1..5) {
+            val m = mInt.toDouble()
+            val data = PoissonRV(m).sample(50000)
+            val params = estimator.estimate(data).getOrThrow()
+            assert(KSLMath.equal(params[0], m, precision = kslPrecision))
+                { "Mean should be $m, was ${params[0]}" }
+        }
     }
 }

--- a/src/test/kotlin/estimations/WeibullParametersTest.kt
+++ b/src/test/kotlin/estimations/WeibullParametersTest.kt
@@ -2,6 +2,7 @@ package estimations
 
 import Data
 import ksl.utilities.math.KSLMath
+import ksl.utilities.random.rvariable.WeibullRV
 import kotlin.test.Test
 
 class WeibullParametersTest {
@@ -25,4 +26,23 @@ class WeibullParametersTest {
         val result = WeibullParameters().estimate(Data.toxocara)
         assert(result.isFailure) { "Estimation should have failed due to non-positive data, was a success" }
     }
+
+    @Test
+    fun estimateKSL() {
+        val kslPrecision = 0.03
+        val estimator = WeibullParameters()
+        for (shapeInt in 1..5) {
+            for (scaleInt in 1..5) {
+                val shape = shapeInt.toDouble()
+                val scale = scaleInt.toDouble()
+                val data = WeibullRV(shape, scale).sample(50000)
+                val params = estimator.estimate(data).getOrThrow()
+                assert(KSLMath.equal(params[0], shape, precision = kslPrecision))
+                    { "Shape should be $shape, was ${params[0]}" }
+                assert(KSLMath.equal(params[1], scale, precision = kslPrecision))
+                    { "Scale should be $scale, was ${params[1]}" }
+            }
+        }
+    }
+
 }

--- a/src/test/kotlin/estimations/WeibullParametersTest.kt
+++ b/src/test/kotlin/estimations/WeibullParametersTest.kt
@@ -9,11 +9,15 @@ class WeibullParametersTest {
     val groundBeefShape = 2.18588486
     val groundBeefScale = 83.34767905
 
+    val tolerance = 0.001
+
     @Test
     fun estimateGroundBeef() {
         val params = WeibullParameters().estimate(Data.groundBeef).getOrThrow()
-        assert(KSLMath.equal(params[0], groundBeefShape)) { "Shape should be $groundBeefShape, was ${params[0]}" }
-        assert(KSLMath.equal(params[1], groundBeefScale)) { "Scale should be $groundBeefScale, was ${params[1]}" }
+        assert(KSLMath.equal(params[0], groundBeefShape, precision = tolerance))
+            { "Shape should be $groundBeefShape, was ${params[0]}" }
+        assert(KSLMath.equal(params[1], groundBeefScale, precision = tolerance))
+            { "Scale should be $groundBeefScale, was ${params[1]}" }
     }
 
     @Test

--- a/src/test/kotlin/estimations/WeibullParametersTest.kt
+++ b/src/test/kotlin/estimations/WeibullParametersTest.kt
@@ -34,7 +34,7 @@ class WeibullParametersTest {
             for (scaleInt in 1..5) {
                 val shape = shapeInt.toDouble()
                 val scale = scaleInt.toDouble()
-                val data = WeibullRV(shape, scale).sample(Data.defaultRVSampleSize)
+                val data = WeibullRV(shape, scale, Data.rvTestStream).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
                 assert(KSLMath.equal(params[0], shape, precision = Data.defaultRVTestTolerance))
                     { "Shape should be $shape, was ${params[0]}" }

--- a/src/test/kotlin/estimations/WeibullParametersTest.kt
+++ b/src/test/kotlin/estimations/WeibullParametersTest.kt
@@ -28,18 +28,17 @@ class WeibullParametersTest {
     }
 
     @Test
-    fun estimateKSL() {
-        val kslPrecision = 0.03
+    fun estimateRV() {
         val estimator = WeibullParameters()
         for (shapeInt in 1..5) {
             for (scaleInt in 1..5) {
                 val shape = shapeInt.toDouble()
                 val scale = scaleInt.toDouble()
-                val data = WeibullRV(shape, scale).sample(50000)
+                val data = WeibullRV(shape, scale).sample(Data.defaultRVSampleSize)
                 val params = estimator.estimate(data).getOrThrow()
-                assert(KSLMath.equal(params[0], shape, precision = kslPrecision))
+                assert(KSLMath.equal(params[0], shape, precision = Data.defaultRVTestTolerance))
                     { "Shape should be $shape, was ${params[0]}" }
-                assert(KSLMath.equal(params[1], scale, precision = kslPrecision))
+                assert(KSLMath.equal(params[1], scale, precision = Data.defaultRVTestTolerance))
                     { "Scale should be $scale, was ${params[1]}" }
             }
         }


### PR DESCRIPTION
Loosen tolerances for some parameter estimations (differences from R's estimations were in the 3rd-4th decimal place).

Add a 3rd test type using KSL's RV classes (Uniform + Triangular excluded since these are being reworked)